### PR TITLE
Feature/vscode checkbox

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,6 +174,8 @@ private:
 
         vbox.pack_start(folder, Gtk::PACK_SHRINK);
 
+        vbox.pack_start(openInCodeCheck, Gtk::PACK_SHRINK);
+
         vbox.pack_start(createButton, Gtk::PACK_SHRINK);
 
         add(vbox);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,6 +144,8 @@ private:
     Gtk::Label labelFolder{"Виберіть папку:"};
     Gtk::Button folder{"Обрати папку"};
 
+    Gtk::CheckButton openInCodeCheck{"Відкрити в Code"};
+
     Gtk::Button createButton{"Створити"};
 
     string folderName;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,6 +226,11 @@ private:
 
             showSuccessDialog("Успіх!", "Папку створено.");
 
+            if (openInCodeCheck.get_active()) {
+                const fs::path fullPath = fs::path(folderName) / contestName;
+                openInCode(fullPath.string());
+            }
+
         } catch (const exception& e) {
             showErrorDialog("Помилка", e.what());
         }
@@ -247,6 +252,10 @@ private:
                 throw invalid_argument("Назва контесту містить заборонений символ: " + c);
             }
         }
+    }
+
+    void openInCode(const string& fullPath) {
+
     }
 
     void showErrorDialog(const string& title, const string& subTitle) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,7 +258,7 @@ private:
         string command;
 
         #ifdef _WIN32
-            command = "code \"" + fullPath + "\"";
+            command = "start \"\" \"%LOCALAPPDATA%\\Programs\\Microsoft VS Code\\Code.exe\" \"" + fullPath + "\"";
         #elif __APPLE__
             command = "open -a \"Visual Studio Code\" \"" + fullPath + "\"";
         #else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,7 +255,21 @@ private:
     }
 
     void openInCode(const string& fullPath) {
+        string command;
 
+        #ifdef _WIN32
+            command = "code \"" + fullPath + "\"";
+        #elif __APPLE__
+            command = "open -a \"Visual Studio Code\" \"" + fullPath + "\"";
+        #else
+            command = "code \"" + fullPath + "\" &";
+        #endif
+
+        int result = system(command.c_str());
+
+        if (result != 0) {
+            throw runtime_error("Не вдалося відкрити Code");
+        }
     }
 
     void showErrorDialog(const string& title, const string& subTitle) {


### PR DESCRIPTION
## Що зроблено
- Додано чекбокс `"Відкрити в Code"` у вікні створення нової директорії.
- Якщо чекбокс натиснутий при створенні директорії, вона автоматично відкривається у **VSCode**.
- Кросплатформна реалізація відкриття **VSCode**:
    - **Windows**: використовується команда 
      ```bash
      start "" "%LOCALAPPDATA%\Programs\Microsoft VS Code\Code.exe" "<шлях_до_директорії>"
      ```
    - **macOS**: використовується команда 
      ```bash
      open -a "Visual Studio Code" "<шлях_до_директорії>"
      ```
    - **Linux**/інші: використовується команда 
      ```bash
      code "<шлях_до_директорії>" &
      ```
- Функціонал не впливає на створення директорії, якщо чекбокс не вибрано.