### PR TITLE
Feature/git-init

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -280,7 +280,14 @@ private:
     }
     
     void createGitRepo(const string& fullPath) {
+        string escapedPath = "\"" + fullPath + "\"";
+        const string command = "cd " + escapedPath + " && git init";
 
+        int result = system(command.c_str());
+
+        if (result != 0) {
+            throw runtime_error("Помилка під час створення Git репозиторію");
+        }
     }
 
     void showErrorDialog(const string& title, const string& subTitle) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,6 +233,11 @@ private:
                 openInCode(fullPath.string());
             }
 
+            if (createGitRepoCheck.get_active()) {
+                const fs::path fullPath = fs::path(folderName) / contestName;
+                createGitRepo(fullPath.string());
+            }
+
         } catch (const exception& e) {
             showErrorDialog("Помилка", e.what());
         }
@@ -272,6 +277,10 @@ private:
         if (result != 0) {
             throw runtime_error("Не вдалося відкрити Code");
         }
+    }
+    
+    void createGitRepo(const string& fullPath) {
+
     }
 
     void showErrorDialog(const string& title, const string& subTitle) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,7 @@ private:
     Gtk::Button folder{"Обрати папку"};
 
     Gtk::CheckButton openInCodeCheck{"Відкрити в Code"};
+    Gtk::CheckButton createGitRepoCheck{"Створити Git репозиторій"};
 
     Gtk::Button createButton{"Створити"};
 
@@ -175,6 +176,7 @@ private:
         vbox.pack_start(folder, Gtk::PACK_SHRINK);
 
         vbox.pack_start(openInCodeCheck, Gtk::PACK_SHRINK);
+        vbox.pack_start(createGitRepoCheck, Gtk::PACK_SHRINK);
 
         vbox.pack_start(createButton, Gtk::PACK_SHRINK);
 


### PR DESCRIPTION
## Що зроблено
- Додано новий чекбокс `"Створити Git репозиторій"` у вікні створення директорії.
- Якщо чекбокс натиснутий при створенні директорії:
  - В обраній директорії автоматично виконується `git init`.
  - Додаткових дій не потрібно, просто створюється порожній репозиторій Git.
- Функціонал кросплатформний:
  - Використовується стандартна команда `git init`, яка працює на Windows, macOS та Linux.
- Функціонал не впливає на створення директорії, якщо чекбокс не вибрано.